### PR TITLE
Property path on the captacha type to false by default

### DIFF
--- a/Type/CaptchaType.php
+++ b/Type/CaptchaType.php
@@ -87,7 +87,8 @@ class CaptchaType extends AbstractType
         return array(
             'width' => $this->width,
             'height' => $this->height,
-            'length' => $this->length
+            'length' => $this->length,
+            'property_path' => false,
         );
     }
 


### PR DESCRIPTION
When adding the captcha widget to an Entity if the entity don't have a captcha member an exception is thrown. This stops this and allows the captcha type to be used as documented.
