### PR TITLE
Modified Session namespace for Symfony 2.1

### DIFF
--- a/Type/CaptchaType.php
+++ b/Type/CaptchaType.php
@@ -2,7 +2,7 @@
 
 namespace Gregwar\CaptchaBundle\Type;
 
-use Symfony\Component\HttpFoundation\Session;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 use Symfony\Component\Form\FormView;

--- a/Validator/CaptchaValidator.php
+++ b/Validator/CaptchaValidator.php
@@ -3,7 +3,7 @@
 namespace Gregwar\CaptchaBundle\Validator;
 
 use Symfony\Component\Form\FormValidatorInterface;
-use Symfony\Component\HttpFoundation\Session;
+use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\Form\FormError;
 


### PR DESCRIPTION
The current CaptchaBundle code throws fatal errors when integrated with Symfony 2.1 due to the Session service changing locations. 

I have updated the namespace in the CaptchaBundle files that use it.

Please let me know if you have questions.
Thanks!
