### PR TITLE
Add invalid_message configuration option

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -31,6 +31,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('gc_freq')->defaultValue(100)->end()
                 ->scalarNode('expiration')->defaultValue(60)->end()
                 ->scalarNode('quality')->defaultValue(15)->end()
+                ->scalarNode('invalid_message')->defaultValue('Bad code value')->end()
             ->end()
         ;
         return $treeBuilder;

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ You can define the following type option :
 * **web_path**: absolute path to public web folder (default="%kernel.root_dir%/../web")
 * **gc_freq**: frequency of garbage collection in fractions of 1 (default=100)
 * **expiration**: maximum lifetime of captcha image files in minutes (default=60)
+* **invalid_message**: error message displayed when an non-matching code is submitted (default="Bad code value")
 
 Example :
 

--- a/Type/CaptchaType.php
+++ b/Type/CaptchaType.php
@@ -29,7 +29,7 @@ class CaptchaType extends AbstractType
      * @var array
      */
     private $options = array();
-    
+
     /**
      * Session key
      * @var string
@@ -47,7 +47,7 @@ class CaptchaType extends AbstractType
         $this->key = $builder->getForm()->getName();
 
         $builder->addValidator(
-            new CaptchaValidator($this->session, $this->key)
+            new CaptchaValidator($this->session, $this->key, $options['invalid_message'])
         );
     }
 
@@ -59,13 +59,13 @@ class CaptchaType extends AbstractType
             $fingerprint = $this->session->get($this->key.'_fingerprint');
         }
 
-        $generator = new CaptchaGenerator($this->generateCaptchaValue(), 
-                                          $options['image_folder'], 
-                                          $options['web_path'], 
-                                          $options['gc_freq'], 
-                                          $options['expiration'], 
-                                          $options['font'], 
-                                          $fingerprint, 
+        $generator = new CaptchaGenerator($this->generateCaptchaValue(),
+                                          $options['image_folder'],
+                                          $options['web_path'],
+                                          $options['gc_freq'],
+                                          $options['expiration'],
+                                          $options['font'],
+                                          $fingerprint,
                                           $options['quality']);
 
         if ($options['as_file']) {
@@ -77,7 +77,7 @@ class CaptchaType extends AbstractType
         if ($options['keep_value']) {
             $this->session->set($this->key.'_fingerprint', $generator->getFingerprint());
         }
-        
+
         $view->addVars(array(
             'captcha_width'     => $options['width'],
             'captcha_height'    => $options['height'],
@@ -88,7 +88,7 @@ class CaptchaType extends AbstractType
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)
     {
-        $this->options['property_path'] = false;        
+        $this->options['property_path'] = false;
         $resolver->setDefaults($this->options);
     }
 

--- a/Validator/CaptchaValidator.php
+++ b/Validator/CaptchaValidator.php
@@ -24,10 +24,16 @@ class CaptchaValidator implements FormValidatorInterface
      */
     private $key;
 
-    public function __construct(Session $session, $key)
+    /**
+     * Error message text for non-matching submissions
+     */
+    private $invalidMessage;
+
+    public function __construct(Session $session, $key, $invalidMessage)
     {
         $this->session = $session;
         $this->key = $key;
+        $this->invalidMessage = $invalidMessage;
     }
 
     public function validate(FormInterface $form)
@@ -37,7 +43,7 @@ class CaptchaValidator implements FormValidatorInterface
 
         if (!($code && $excepted_code && is_string($code) && is_string($excepted_code)
             && $this->niceize($code) == $this->niceize($excepted_code))) {
-            $form->addError(new FormError('Bad code value'));
+            $form->addError(new FormError($this->invalidMessage));
         }
 
         $this->session->remove($this->key);
@@ -61,7 +67,7 @@ class CaptchaValidator implements FormValidatorInterface
     /**
      * Process the codes
      */
-    private function niceize($code) 
+    private function niceize($code)
     {
         return strtr(strtolower($code), 'oil', '01l');
     }


### PR DESCRIPTION
This modification gives the ability to use an invalid_message configuration parameter to override the default "Bad code value" message.
