### PR TITLE
Add bypass_code configuration parameter

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -32,6 +32,7 @@ class Configuration implements ConfigurationInterface
                 ->scalarNode('expiration')->defaultValue(60)->end()
                 ->scalarNode('quality')->defaultValue(15)->end()
                 ->scalarNode('invalid_message')->defaultValue('Bad code value')->end()
+                ->scalarNode('bypass_code')->defaultValue(null)->end()
             ->end()
         ;
         return $treeBuilder;

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ You can define the following type option :
 * **gc_freq**: frequency of garbage collection in fractions of 1 (default=100)
 * **expiration**: maximum lifetime of captcha image files in minutes (default=60)
 * **invalid_message**: error message displayed when an non-matching code is submitted (default="Bad code value")
+* **bypass_code**: code that will always validate the captcha (default=null)
 
 Example :
 

--- a/Type/CaptchaType.php
+++ b/Type/CaptchaType.php
@@ -47,7 +47,10 @@ class CaptchaType extends AbstractType
         $this->key = $builder->getForm()->getName();
 
         $builder->addValidator(
-            new CaptchaValidator($this->session, $this->key, $options['invalid_message'])
+            new CaptchaValidator($this->session,
+                                 $this->key,
+                                 $options['invalid_message'],
+                                 $options['bypass_code'])
         );
     }
 


### PR DESCRIPTION
This successfully validates the captcha when it is submitted with a code that is equal to the configured bypass_code. This is primarily beneficial for automation scripts in development and testing environments.
