### PR TITLE
Switch suggested git URL to http:// instead of git://

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Add the following lines to your `deps` file:
 
 ```
     [GregwarCaptchaBundle]
-        git=git://github.com/Gregwar/CaptchaBundle.git
+        git=http://github.com/Gregwar/CaptchaBundle.git
         target=/bundles/Gregwar/CaptchaBundle
         version=origin/2.0 <- add this if you are using Symfony 2.0
 ```


### PR DESCRIPTION
A git url of git://github.com/Gregwar/CaptchaBundle.git didn't work for me.

http:// is more reliable, and is used by all the deps in the symfony standard edition  http://github.com/symfony/symfony-standard/blob/2.0/deps
