### PR TITLE
Fix Bundle for symfony 2.1 beta4

### DIFF
--- a/Type/CaptchaType.php
+++ b/Type/CaptchaType.php
@@ -54,7 +54,7 @@ class CaptchaType extends AbstractType
         );
     }
 
-    public function buildView(FormViewInterface $view, FormInterface $form, array $options)
+    public function buildView(FormView $view, FormInterface $form, array $options)
     {
         $fingerprint = null;
 


### PR DESCRIPTION
Hi There,

There is a problem with the latest symfony 2.1 beta 4. 

PHP Fatal error:  Declaration of Gregwar\CaptchaBundle\Type\CaptchaType::buildView() must be compatible with that of Symfony\Component\Form\FormTypeInterface::buildView() in /opt/testsite/releases/20120713090800/vendor/gregwar/captcha-bundle/Gregwar/CaptchaBundle/Type/CaptchaType.php on line 125

I think this commit to the buildView API broke the bundle:

https://github.com/symfony/symfony/commit/d072f35ea0166004b6407d510ec9f484f8eef78a#src/Symfony/Component/Form/FormTypeInterface.php

Cheers,

Alex
