### PR TITLE
Fixing call to undefined methode

### DIFF
--- a/Type/CaptchaType.php
+++ b/Type/CaptchaType.php
@@ -81,12 +81,16 @@ class CaptchaType extends AbstractType
             $this->session->set($this->key.'_fingerprint', $generator->getFingerprint());
         }
 
-        $view->addVars(array(
+        $fieldVars = array(
             'captcha_width'     => $options['width'],
             'captcha_height'    => $options['height'],
             'captcha_code'      => $captchaCode,
             'value'             => '',
-        ));
+        );
+
+        foreach($fieldVars as $name => $value){
+            $view->set($name,$value);    
+        }
     }
 
     public function setDefaultOptions(OptionsResolverInterface $resolver)


### PR DESCRIPTION
After testing my forms I discovered another api change in symfony´s form api:

[Tue Jul 24 15:18:07 2012] [error] [client 127.0.0.1] PHP Fatal error:  Call to undefined method Symfony\Component\Form\FormView
::addVars() in /opt/testsite/releases/20120713090800/vendor/gregwar/captcha-bundle/Gregwar/CaptchaBundle/Type/CaptchaType.php on 
line 84
