### PR TITLE
Call ob_clean to prevent corrupted images

### DIFF
--- a/Generator/CaptchaGenerator.php
+++ b/Generator/CaptchaGenerator.php
@@ -132,6 +132,9 @@ class CaptchaGenerator
         }
 
         if (!$options['as_file']) {
+        	// Clean output buffer to prevent corrupted images
+        	ob_clean();
+        	
             ob_start();
             imagejpeg($content, null, $options['quality']);
 


### PR DESCRIPTION
When I tried to use the captcha as an url my images became corrupt. 

I'm not sure whether it is my installation, but cleaning the output buffer before starting fixed my issue.
