### PR TITLE
Fix: Numeric bypass code defaults to integer type

### DIFF
--- a/Validator/CaptchaValidator.php
+++ b/Validator/CaptchaValidator.php
@@ -60,7 +60,7 @@ class CaptchaValidator
         $this->session          = $session;
         $this->key              = $key;
         $this->invalidMessage   = $invalidMessage;
-        $this->bypassCode       = $bypassCode;
+        $this->bypassCode       = (string)$bypassCode;
         $this->humanity         = $humanity;
     }
 


### PR DESCRIPTION
When adding a numeric only bypass code into config.yml, it is treated as an integer which causes validation to fail. A workaround is to surround the parameter with double quotes but many users may not be aware of this. This fix will explicitly convert it to a string.