### PR TITLE
Don't cache captcha image

### DIFF
--- a/Resources/views/captcha.html.twig
+++ b/Resources/views/captcha.html.twig
@@ -3,7 +3,7 @@
 -
 {% else %}
 {% spaceless %}
-    <img id="{{ image_id }}" src="{{ captcha_code }}" alt="" title="captcha" width="{{ captcha_width }}" height="{{ captcha_height }}" />
+    <img id="{{ image_id }}" src="{{ captcha_code }}?n={{ 'now'|date('U') }}" alt="" title="captcha" width="{{ captcha_width }}" height="{{ captcha_height }}" />
     {% if reload %}
     <script type="text/javascript">
         function reload_{{ image_id }}() {
@@ -17,4 +17,3 @@
 {% endspaceless %}
 {% endif %}
 {% endblock %}
-


### PR DESCRIPTION
Small fix - add current timestamp to url. Browser don't cache captcha when you get form by ajax request and probably fix #97