### PR TITLE
Replaced usage of "pattern" with "path"

### DIFF
--- a/Resources/config/routing/routing.yml
+++ b/Resources/config/routing/routing.yml
@@ -1,3 +1,3 @@
 gregwar_captcha.generate_captcha:
-    pattern:        /generate-captcha/{key}
+    path:           /generate-captcha/{key}
     defaults:       { _controller: GregwarCaptchaBundle:Captcha:generateCaptcha }


### PR DESCRIPTION
Replaced deprecated "pattern" with "path". As described in issue #135