### PR TITLE
POST_BIND deprecated

### DIFF
--- a/Type/CaptchaType.php
+++ b/Type/CaptchaType.php
@@ -71,7 +71,7 @@ class CaptchaType extends AbstractType
             $options['humanity']
         );
 
-        $builder->addEventListener(FormEvents::POST_BIND, array($validator, 'validate'));
+        $builder->addEventListener(FormEvents::POST_SUBMIT, array($validator, 'validate'));
     }
 
     /**

--- a/Type/CaptchaType.php
+++ b/Type/CaptchaType.php
@@ -70,8 +70,8 @@ class CaptchaType extends AbstractType
             $options['bypass_code'],
             $options['humanity']
         );
-
-        $builder->addEventListener(FormEvents::POST_SUBMIT, array($validator, 'validate'));
+        $event = \Symfony\Component\HttpKernel\Kernel::VERSION >= 2.3 ? FormEvents::POST_SUBMIT : FormEvents::POST_BIND;
+        $builder->addEventListener($event, array($validator, 'validate'));
     }
 
     /**


### PR DESCRIPTION
POST_BIND deprecated since version 2.3, to be removed in 3.0. Use POST_SUBMIT instead.