### PR TITLE
Changed template reference

### DIFF
--- a/DependencyInjection/GregwarCaptchaExtension.php
+++ b/DependencyInjection/GregwarCaptchaExtension.php
@@ -34,6 +34,6 @@ class GregwarCaptchaExtension extends Extension
         $container->setParameter('gregwar_captcha.config.whitelist_key', $config['whitelist_key']);
 
         $resources = $container->getParameter('twig.form.resources');
-        $container->setParameter('twig.form.resources', array_merge(array('GregwarCaptchaBundle::captcha.html.twig'), $resources));
+        $container->setParameter('twig.form.resources', array_merge(array('@GregwarCaptcha/captcha.html.twig'), $resources));
     }
 }


### PR DESCRIPTION
Compatibility for Symfony4

According to:
https://symfony.com/doc/current/templating.html#referencing-templates-in-a-bundle

Fixed error:
[critical] Uncaught PHP Exception Twig_Error_Loader: "Unable to find template "GregwarCaptchaBundle::captcha.html.twig" (looked into: /[path]/templates, /[path]/templates, /[path]/vendor/symfony/twig-bridge/Resources/views/Form)." at /[path]/templates/form.html.twig line 17