### PR TITLE
Fixed deprecated TreeBuilder::root method call in SF 4

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -14,8 +14,14 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('gregwar_captcha');
+        $treeBuilder = new TreeBuilder('gregwar_captcha');
+
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC for symfony/config <= 4.1
+            $rootNode = $treeBuilder->root('gregwar_captcha');
+        }
 
         $rootNode
             ->addDefaultsIfNotSet()


### PR DESCRIPTION
In Symfony 4 configuration root name should be passed via constructor instead of using `Symfony\Component\Config\Definition\Builder\TreeBuilder::root` method, otherwise  deprecation warning is emitted: 

```
The "Symfony\Component\Config\Definition\Builder\TreeBuilder::root()" method called for the "gregwar_captcha" configuration is deprecated since Symfony 4.3, pass the root name to the constructor instead.
```

More information:
* https://symfony.com/blog/new-in-symfony-4-2-important-deprecations#deprecated-tree-builders-without-root-nodes
* https://github.com/symfony/symfony/blob/master/UPGRADE-4.2.md#config