### PR TITLE
Removed deprecated spaceless tag

### DIFF
--- a/Resources/views/captcha.html.twig
+++ b/Resources/views/captcha.html.twig
@@ -2,7 +2,7 @@
 {% if is_human %}
 -
 {% else %}
-{% spaceless %}
+{% apply spaceless %}
     <img class="captcha_image" id="{{ image_id }}" src="{{ captcha_code }}" alt="" title="captcha" width="{{ captcha_width }}" height="{{ captcha_height }}" />
     {% if reload %}
     <script type="text/javascript">
@@ -14,6 +14,6 @@
     <a class="captcha_reload" href="javascript:reload_{{ image_id }}();">{{ 'Renew'|trans({}, 'gregwar_captcha') }}</a>
     {% endif %}
     {{ form_widget(form) }}
-{% endspaceless %}
+{% endapply %}
 {% endif %}
 {% endblock %}

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,8 @@
         "php": ">=5.3.9",
         "gregwar/captcha": "~1.1",
         "symfony/framework-bundle": "~2.8|~3.0|~4.0",
-        "symfony/form": "~2.8|~3.0|~4.0"
+        "symfony/form": "~2.8|~3.0|~4.0",
+        "twig/twig": "^1.40|^2.9"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Since Twig 2.7 `spaceless` tag is deprecated and should be replaced by `spaceless` filter, otherwise deprecation warning is emitted:

```
The spaceless tag in "@GregwarCaptcha/captcha.html.twig" at line 5 is deprecated since Twig 2.7, use the spaceless filter instead.
```

More information:
* https://twig.symfony.com/doc/2.x/deprecated.html#tags
