### PR TITLE
Make Validator fields accessible from child classes.

### DIFF
--- a/Validator/CaptchaValidator.php
+++ b/Validator/CaptchaValidator.php
@@ -17,42 +17,42 @@ use Symfony\Contracts\Translation\TranslatorInterface;
 class CaptchaValidator
 {
     /** @var SessionInterface */
-    private $session;
+    protected $session;
 
     /**
      * Session key to store the code.
      *
      * @var string
      */
-    private $key;
+    protected $key;
 
     /**
      * Error message text for non-matching submissions.
      *
      * @var string
      */
-    private $invalidMessage;
+    protected $invalidMessage;
 
     /**
      * Configuration parameter used to bypass a required code match.
      *
      * @var string
      */
-    private $bypassCode;
+    protected $bypassCode;
 
     /**
      * Number of form that the user can submit without captcha.
      *
      * @var int
      */
-    private $humanity;
+    protected $humanity;
 
     /**
      * Translator.
      *
      * @var TranslatorInterface
      */
-    private $translator;
+    protected $translator;
 
     public function __construct(
         TranslatorInterface $translator,


### PR DESCRIPTION
I suggest a small change in the `CaptchaValidator` class. In order to be able to inherit the class I changed the visibility of all fields from `private` to `protected`. Nothing big, just makes it easier to extend the validator.