### PR TITLE
Complete sf5 compatibility

### DIFF
--- a/Controller/CaptchaController.php
+++ b/Controller/CaptchaController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Gregwar\CaptchaBundle\Controller;
 
 use Gregwar\CaptchaBundle\Generator\CaptchaGenerator;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -14,7 +13,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Jeremy Livingston <jeremy.j.livingston@gmail.com>
  */
-class CaptchaController extends AbstractController
+class CaptchaController
 {
     /** @var CaptchaGenerator */
     private $captchaGenerator;

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -8,10 +8,6 @@ parameters:
     
 services:
     Gregwar\CaptchaBundle\Controller\CaptchaController:
-        public: true
-        alias: 'gregwar_captcha.controller'
-
-    gregwar_captcha.controller:
         class: '%gregwar_captcha.controller.class%'
         public: true
         arguments:
@@ -23,7 +19,6 @@ services:
 #    captcha.type:
     gregwar_captcha.type:
         class: '%gregwar_captcha.captcha_type.class%'
-        public: true
         arguments:
             - '@session'
             - '@gregwar_captcha.generator'
@@ -34,7 +29,6 @@ services:
 
     gregwar_captcha.generator:
         class: '%gregwar_captcha.captcha_generator.class%'
-        public: true
         arguments:
             - '@router'
             - '@gregwar_captcha.captcha_builder'
@@ -43,7 +37,6 @@ services:
 
     gregwar_captcha.image_file_handler:
         class: '%gregwar_captcha.image_file_handler.class%'
-        public: true
         arguments:
             - '%gregwar_captcha.config.image_folder%'
             - '%gregwar_captcha.config.web_path%'
@@ -52,8 +45,6 @@ services:
 
     gregwar_captcha.captcha_builder:
         class: '%gregwar_captcha.captcha_builder.class%'
-        public: true
 
     gregwar_captcha.phrase_builder:
         class: '%gregwar_captcha.phrase_builder.class%'
-        public: true

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -17,6 +17,8 @@ services:
         arguments:
             - '@gregwar_captcha.generator'
             - '%gregwar_captcha.config%'
+        tags:
+            - controller.service_arguments
 
 #    captcha.type:
     gregwar_captcha.type:


### PR DESCRIPTION
I had a problem when migrating a project to Symfony 5.

The container crashes during compilation because `setContainer` of `CaptchaController` was not called (and it's normal because `CaptchaController` is not autowired). To fix this, this PR:
- Remove `extends AbstractController` since `CaptchaController` doesn't use its services/methods anymore
- Add `controller.service_arguments` tag to the controller to allow it to be registered even if it doesn't extends `AbstractController` anymore.

I'm suggesting some other changes to match better with the sf4/sf5 DI philosophy:
- Services only need to be public if they are retrieved with `$container->get('myservice')`; I think none of the services of this bundle are concerned.
- The controller alias is not needed, the `controller.service_arguments` tag (and previously the `AbstractController` parent class) allows to make the service public.