### PR TITLE
Inject service locator instead of the whole container

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -17,7 +17,10 @@ services:
         arguments:
             - '@gregwar_captcha.generator'
             - '%gregwar_captcha.config%'
-        autowire: true
+        calls:
+            - setContainer: []
+        tags:
+            - container.service_subscriber
 
 #    captcha.type:
     gregwar_captcha.type:


### PR DESCRIPTION
This PR fixes the container injection problem raised in #213 

The best way to resolve that is still to remove the AbstractController dependency. But even though the probability is weak, this might cause backward compatibility breaks. It's why this PR replaces the previous.