### PR TITLE
fix PSR-4 path

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Gregwar\\CaptchaBundle\\": "/"
+            "Gregwar\\CaptchaBundle\\": ""
         }
     },
     "config": {


### PR DESCRIPTION
Follow-up to #126. 😏

Reason: Pointing to the filesystem's root is not valid.

Note: This fix should probably target the 2.1 code branch which doesn't exist in the repo yet.