### PR TITLE
Add Symfony 7 in required version for Symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         "php": ">=7.1.3",
         "ext-gd": "*",
         "gregwar/captcha": "^1.1.9",
-        "symfony/form": "~5.0|~6.0",
-        "symfony/framework-bundle": "~5.0|~6.0",
-        "symfony/translation": "~5.0|^6.0",
+        "symfony/form": "~5.0|~6.0|~7.0",
+        "symfony/framework-bundle": "~5.0|~6.0|~7.0",
+        "symfony/translation": "~5.0|^6.0|~7.0",
         "twig/twig": "^2.10|^3.0"
     },
     "autoload": {


### PR DESCRIPTION
Not fully tested on Symfony 7.0. But Kernel boot successfully.