### PR TITLE
fix(chore): deprecation of Extension

### DIFF
--- a/DependencyInjection/GregwarCaptchaExtension.php
+++ b/DependencyInjection/GregwarCaptchaExtension.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Gregwar\CaptchaBundle\DependencyInjection;
 
 use Exception;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\Config\FileLocator;


### PR DESCRIPTION
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Gregwar\CaptchaBundle\DependencyInjection\GregwarCaptchaExtension".